### PR TITLE
fix: don't check for refresh all the time

### DIFF
--- a/Hearths.toc
+++ b/Hearths.toc
@@ -1,8 +1,19 @@
 ## Interface: 110200
 ## Title: Hearths
-## Version: 0.4
+## Version: 0.5
 ## Notes: Hearthstone Rotation
 ## Author: Rickard Dybeck
 ## SavedVariablesPerCharacter: HearthsDB
+## Category: Collections
+## Category-deDE: Kriegsmeutesammlungen
+## Category-esES: Colecciones de banda guerrera
+## Category-esMX: Colecciones de tropa
+## Category-frFR: Collections du bataillon
+## Category-itIT: Collezioni della Brigata
+## Category-koKR: 전투부대 수집품
+## Category-ptBR: Coleções do Bando de Guerra
+## Category-ruRU: Коллекции отряда
+## Category-zhCN: 战团藏品
+## Category-zhTW: 戰隊收藏
 
 Hearths.lua


### PR DESCRIPTION
fix an issue where cooldown of hearthstones would be checked all the time, sometimes causing it to try to update in combat and changing the icon but not the button target