### PR TITLE
fix(toy-scanning): ensure only collected toys are included

### DIFF
--- a/Hearths.lua
+++ b/Hearths.lua
@@ -448,12 +448,12 @@ function ScanHearthstoneToys()
         DebugPrint("Added to rotation: " .. astralRecall.name)
     end
 
-    -- Scan toy box for hearthstone toys
-    local numToys = C_ToyBox.GetNumFilteredToys()
+    -- Scan toy box for hearthstone toys (ignore current filters)
+    local numToys = C_ToyBox.GetNumToys()
     DebugPrint("Scanning " .. numToys .. " toys in toy box...")
     for i = 1, numToys do
         local toyID = C_ToyBox.GetToyFromIndex(i)
-        if toyID and toyID > 0 and C_ToyBox.IsToyUsable(toyID) then
+        if toyID and toyID > 0 and C_ToyBox.IsToyUsable(toyID) and PlayerHasToy(toyID) then
             local itemID, toyName, icon = C_ToyBox.GetToyInfo(toyID)
 
             if toyName and type(toyName) == "string" then

--- a/Hearths.toc
+++ b/Hearths.toc
@@ -1,6 +1,6 @@
 ## Interface: 110200
 ## Title: Hearths
-## Version: 0.6
+## Version: 0.7
 ## Notes: Hearthstone Rotation
 ## Author: Rickard Dybeck
 ## SavedVariablesPerCharacter: HearthsDB


### PR DESCRIPTION
- Add PlayerHasToy() check to only include collected toys in rotation
- Use C_ToyBox.GetNumToys() instead of GetNumFilteredToys() to ignore toy box filters
- Bump version to 0.7

The addon was previously picking up non-collected toys and respecting toy box filters, which could lead to unexpected behavior when players had specific filters active.