### PR TITLE
fix: restore current hearthstone on login

### DIFF
--- a/App.lua
+++ b/App.lua
@@ -19,49 +19,38 @@ local RACE_RESTRICTED_TOYS = {
 	[210455] = { ["Draenei"] = true, ["LightforgedDraenei"] = true }, -- Draenic Hologem
 }
 
-local RETRY_DELAY_SECONDS = 1
-local MAX_RETRY_ATTEMPTS = 10
+local LOGIN_LOAD_DELAY_SECONDS = 3
 
 function App:Initialize()
 	self.scanningTooltip = nil
 	self.isScanning = false
-	self.retryAttempts = 0
 end
 
 function App:OnPlayerEnteringWorld()
+	if self.scanningTooltip then
+		return
+	end
+
 	-- Initialize hidden scanning tooltip for item description parsing
 	self.scanningTooltip = CreateFrame("GameTooltip", "HearthsScanningTooltip", UIParent, "GameTooltipTemplate")
 	self.scanningTooltip:SetOwner(UIParent, "ANCHOR_NONE")
 
-	self:InitializeWithRetry()
+	C_Timer.After(LOGIN_LOAD_DELAY_SECONDS, function()
+		self:LoadCurrentHearthstone()
+	end)
 end
 
 function App:OnNewToyAdded()
 	self:RefreshAvailableHearthstones()
 end
 
-function App:OnLoadingScreenDisabled()
-	-- Delay for toy box data to be ready
-	C_Timer.After(RETRY_DELAY_SECONDS, function()
-		self:RefreshAvailableHearthstones()
-		self:RefreshSelectedHearthstone()
-	end)
-end
-
-function App:InitializeWithRetry()
-	if C_ToyBox.GetNumToys() == 0 then
-		self.retryAttempts = self.retryAttempts + 1
-		if self.retryAttempts <= MAX_RETRY_ATTEMPTS then
-			Hearths.Debug:Log("App", "ToyBox", "Toy box not loaded yet, retrying... (" .. self.retryAttempts .. "/" .. MAX_RETRY_ATTEMPTS .. ")")
-			C_Timer.After(RETRY_DELAY_SECONDS, function() self:InitializeWithRetry() end)
-			return
-		else
-			Hearths.Debug:Log("App", "ToyBox", "Toy box failed to load after " .. MAX_RETRY_ATTEMPTS .. " attempts")
-			return
-		end
+function App:LoadCurrentHearthstone()
+	local currentHearthstone = Hearths.UI:GetCurrentHearthstone()
+	if currentHearthstone then
+		Hearths:SendMessage("HEARTHS_SELECTION_CHANGED", currentHearthstone)
+		return
 	end
 
-	-- Toy box is ready
 	self:RefreshAvailableHearthstones()
 	self:RefreshSelectedHearthstone()
 end

--- a/Core.lua
+++ b/Core.lua
@@ -41,8 +41,6 @@ end
 
 function Hearths:OnEnable()
 	self:RegisterEvent("PLAYER_ENTERING_WORLD", function()
-		-- The app may select a hearthstone synchronously when toy data is ready.
-		-- Create the secure button first so that selection is not discarded.
 		self.UI:OnPlayerEnteringWorld()
 		self.App:OnPlayerEnteringWorld()
 	end)
@@ -51,9 +49,6 @@ function Hearths:OnEnable()
 	end)
 	self:RegisterEvent("NEW_TOY_ADDED", function()
 		self.App:OnNewToyAdded()
-	end)
-	self:RegisterEvent("LOADING_SCREEN_DISABLED", function()
-		self.App:OnLoadingScreenDisabled()
 	end)
 end
 

--- a/UI.lua
+++ b/UI.lua
@@ -12,6 +12,30 @@ function UI:OnPlayerEnteringWorld()
 	self.hearthsButton = self:CreateHearthstoneButton()
 end
 
+function UI:GetCurrentHearthstone()
+	local macroIndex = GetMacroIndexByName(self.macroName)
+	if macroIndex == 0 then
+		return nil
+	end
+
+	local _, _, macroBody = GetMacroInfo(macroIndex)
+	if not macroBody then
+		return nil
+	end
+
+	local itemId = tonumber(string.match(macroBody, "#showtooltip%s+item:(%d+)"))
+	if itemId then
+		local defaultId = Hearths.App:GetHearthstoneIDs().DEFAULT
+		return { id = itemId, kind = itemId == defaultId and "item" or "toy" }
+	end
+
+	if string.find(macroBody, "#showtooltip Astral Recall", 1, true) then
+		return { id = Hearths.App:GetHearthstoneIDs().ASTRAL_RECALL, kind = "spell" }
+	end
+
+	return nil
+end
+
 function UI:OnCombatEnd()
 	-- Process any macro updates once out of combat
 	if self.triedRefreshInCombat then


### PR DESCRIPTION
Wait briefly after entering the world, then restore the hearthstone already recorded in the HEARTHS_BTN macro. This avoids depending on toybox data during cold login and preserves the user's current choice.

Fall back to scanning and selecting a hearthstone when no valid macro exists. Stop rerolling after every loading screen, since those updates could replace the restored selection unexpectedly.